### PR TITLE
Fix missing project_limits table after install

### DIFF
--- a/project-monitoring-system/FIX_PROJECT_LIMITS_ERROR.md
+++ b/project-monitoring-system/FIX_PROJECT_LIMITS_ERROR.md
@@ -1,0 +1,75 @@
+# Fix for Project Limits Table Error
+
+## Problem
+After installation, the script encounters this error:
+```
+SQLSTATE[42S02]: Base table or view not found: 1146 
+project_limits' doesn't exist in 
+getUserUrlLimit() #3 {main} thrown in includes/roles.php on line 66
+```
+
+## Cause
+The `project_limits` table is missing from the database. This table is required by the role management system to track how many projects each user can create.
+
+## Solution
+
+### Option 1: Run the PHP Fix Script (Recommended)
+1. Navigate to your project directory
+2. Run the fix script:
+   ```bash
+   php fix_database_error.php
+   ```
+3. The script will:
+   - Check if the table exists
+   - Create the missing table if needed
+   - Add default project limits for existing users
+   - Test the functionality
+
+### Option 2: Run the SQL Script Manually
+1. Connect to your MySQL database
+2. Run the SQL script:
+   ```bash
+   mysql -u your_username -p your_database < fix_project_limits_table.sql
+   ```
+
+### Option 3: Run SQL Commands Directly
+1. Connect to your MySQL database:
+   ```bash
+   mysql -u your_username -p your_database
+   ```
+2. Execute the following SQL:
+   ```sql
+   CREATE TABLE IF NOT EXISTS `project_limits` (
+       `id` INT(11) NOT NULL AUTO_INCREMENT,
+       `user_id` INT(11) NOT NULL,
+       `max_projects` INT(11) NOT NULL DEFAULT 10,
+       `set_by_admin_id` INT(11) DEFAULT NULL,
+       `limit_message` TEXT DEFAULT NULL,
+       `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+       `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+       PRIMARY KEY (`id`),
+       UNIQUE KEY `unique_user_limit` (`user_id`),
+       KEY `fk_set_by_admin` (`set_by_admin_id`),
+       CONSTRAINT `fk_project_limits_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE,
+       CONSTRAINT `fk_project_limits_admin` FOREIGN KEY (`set_by_admin_id`) REFERENCES `users` (`id`) ON DELETE SET NULL
+   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+   ```
+
+## What This Table Does
+The `project_limits` table:
+- Stores the maximum number of projects each user can create
+- Default limit is 10 projects per user
+- Administrators can set custom limits for specific users
+- Includes optional messages explaining why limits were set
+
+## Prevention
+To prevent this issue in future installations:
+1. Run the installation script (`install.php`) which should create all tables
+2. Or manually run the auto-setup database script
+3. Check that all required tables are created after installation
+
+## Related Files
+- `includes/roles.php` - Contains functions that use this table
+- `includes/auto_setup_database.php` - Contains the table creation logic
+- `fix_database_error.php` - Script to fix the issue
+- `fix_project_limits_table.sql` - SQL script to create the table

--- a/project-monitoring-system/db_complete.sql
+++ b/project-monitoring-system/db_complete.sql
@@ -1,0 +1,101 @@
+-- Project Monitoring System Complete Database Schema
+-- This file includes ALL required tables for the system to function properly
+-- 
+-- Instructions for Hostinger:
+-- 1. Create a new MySQL database in your Hostinger control panel
+-- 2. Open phpMyAdmin from your Hostinger control panel
+-- 3. Select your database
+-- 4. Click on "SQL" tab
+-- 5. Copy and paste this entire script
+-- 6. Click "Go" to execute
+
+-- Create users table
+CREATE TABLE IF NOT EXISTS `users` (
+    `id` INT(11) NOT NULL AUTO_INCREMENT,
+    `username` VARCHAR(50) NOT NULL,
+    `full_name` VARCHAR(100) NOT NULL,
+    `email` VARCHAR(100) NOT NULL,
+    `password_hash` VARCHAR(255) NOT NULL,
+    `role` ENUM('admin', 'user') DEFAULT 'user',
+    `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `unique_email` (`email`),
+    UNIQUE KEY `unique_username` (`username`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Create roles table
+CREATE TABLE IF NOT EXISTS `roles` (
+    `id` INT(11) NOT NULL AUTO_INCREMENT,
+    `role_name` VARCHAR(50) NOT NULL,
+    `can_create_projects` BOOLEAN DEFAULT TRUE,
+    `can_edit_own_projects` BOOLEAN DEFAULT TRUE,
+    `can_delete_own_projects` BOOLEAN DEFAULT TRUE,
+    `can_view_all_projects` BOOLEAN DEFAULT FALSE,
+    `can_edit_all_projects` BOOLEAN DEFAULT FALSE,
+    `can_delete_all_projects` BOOLEAN DEFAULT FALSE,
+    `can_manage_users` BOOLEAN DEFAULT FALSE,
+    `can_manage_roles` BOOLEAN DEFAULT FALSE,
+    `is_system_role` BOOLEAN DEFAULT FALSE,
+    `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `unique_role_name` (`role_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Create project_limits table (IMPORTANT: This was missing in original schema)
+CREATE TABLE IF NOT EXISTS `project_limits` (
+    `id` INT(11) NOT NULL AUTO_INCREMENT,
+    `user_id` INT(11) NOT NULL,
+    `max_projects` INT(11) NOT NULL DEFAULT 10,
+    `set_by_admin_id` INT(11) DEFAULT NULL,
+    `limit_message` TEXT DEFAULT NULL,
+    `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `unique_user_limit` (`user_id`),
+    KEY `fk_set_by_admin` (`set_by_admin_id`),
+    CONSTRAINT `fk_project_limits_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE,
+    CONSTRAINT `fk_project_limits_admin` FOREIGN KEY (`set_by_admin_id`) REFERENCES `users` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Create projects table
+CREATE TABLE IF NOT EXISTS `projects` (
+    `id` INT(11) NOT NULL AUTO_INCREMENT,
+    `user_id` INT(11) NOT NULL,
+    `project_name` VARCHAR(200) NOT NULL,
+    `project_url` VARCHAR(255) DEFAULT NULL,
+    `description` TEXT,
+    `server_location` VARCHAR(100) DEFAULT NULL,
+    `last_checked` TIMESTAMP NULL DEFAULT NULL,
+    `monitoring_region` VARCHAR(100) DEFAULT 'North America',
+    `date_created` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    KEY `fk_user_id` (`user_id`),
+    CONSTRAINT `fk_projects_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Create incidents table
+CREATE TABLE IF NOT EXISTS `incidents` (
+    `id` INT(11) NOT NULL AUTO_INCREMENT,
+    `project_id` INT(11) NOT NULL,
+    `status` ENUM('Open', 'Resolved') NOT NULL DEFAULT 'Open',
+    `root_cause` TEXT NOT NULL,
+    `started_at` DATETIME NOT NULL,
+    `duration` VARCHAR(50) DEFAULT NULL,
+    `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    KEY `fk_project_id` (`project_id`),
+    KEY `idx_status` (`status`),
+    CONSTRAINT `fk_incidents_project` FOREIGN KEY (`project_id`) REFERENCES `projects` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Insert default roles
+INSERT IGNORE INTO `roles` (`role_name`, `can_create_projects`, `can_edit_own_projects`, `can_delete_own_projects`, `can_view_all_projects`, `can_edit_all_projects`, `can_delete_all_projects`, `can_manage_users`, `can_manage_roles`, `is_system_role`) VALUES
+('admin', TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE),
+('user', TRUE, TRUE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE);
+
+-- Create indexes for better performance
+CREATE INDEX IF NOT EXISTS `idx_user_email` ON `users` (`email`);
+CREATE INDEX IF NOT EXISTS `idx_project_user` ON `projects` (`user_id`);
+CREATE INDEX IF NOT EXISTS `idx_incident_project` ON `incidents` (`project_id`);

--- a/project-monitoring-system/fix_database_error.php
+++ b/project-monitoring-system/fix_database_error.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Fix Database Error Script
+ * This script creates the missing project_limits table to resolve the error:
+ * "SQLSTATE[42S02]: Base table or view not found: 1146 project_limits' doesn't exist"
+ */
+
+require_once 'db.php';
+
+try {
+    echo "Starting database fix...\n\n";
+    
+    // Check if project_limits table exists
+    $checkTable = $pdo->query("SHOW TABLES LIKE 'project_limits'");
+    if ($checkTable->rowCount() > 0) {
+        echo "✓ Table 'project_limits' already exists.\n";
+    } else {
+        echo "✗ Table 'project_limits' is missing. Creating it now...\n";
+        
+        // Create the project_limits table
+        $createTableSQL = "
+            CREATE TABLE IF NOT EXISTS `project_limits` (
+                `id` INT(11) NOT NULL AUTO_INCREMENT,
+                `user_id` INT(11) NOT NULL,
+                `max_projects` INT(11) NOT NULL DEFAULT 10,
+                `set_by_admin_id` INT(11) DEFAULT NULL,
+                `limit_message` TEXT DEFAULT NULL,
+                `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (`id`),
+                UNIQUE KEY `unique_user_limit` (`user_id`),
+                KEY `fk_set_by_admin` (`set_by_admin_id`),
+                CONSTRAINT `fk_project_limits_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE,
+                CONSTRAINT `fk_project_limits_admin` FOREIGN KEY (`set_by_admin_id`) REFERENCES `users` (`id`) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        ";
+        
+        $pdo->exec($createTableSQL);
+        echo "✓ Table 'project_limits' created successfully.\n";
+        
+        // Add default project limits for existing users
+        $insertDefaultLimits = "
+            INSERT IGNORE INTO `project_limits` (`user_id`, `max_projects`)
+            SELECT `id`, 10 FROM `users`
+            WHERE `id` NOT IN (SELECT `user_id` FROM `project_limits`)
+        ";
+        
+        $affectedRows = $pdo->exec($insertDefaultLimits);
+        echo "✓ Added default project limits for $affectedRows existing users.\n";
+    }
+    
+    // Test the getUserProjectLimit function
+    echo "\nTesting the getUserProjectLimit function...\n";
+    require_once 'includes/roles.php';
+    
+    // Get all users to test
+    $users = $pdo->query("SELECT id, username FROM users LIMIT 5")->fetchAll();
+    
+    if (count($users) > 0) {
+        foreach ($users as $user) {
+            $limit = getUserProjectLimit($user['id']);
+            echo "- User '{$user['username']}' (ID: {$user['id']}): Project limit = $limit\n";
+        }
+        echo "\n✓ Function is working correctly!\n";
+    } else {
+        echo "No users found in the database to test with.\n";
+    }
+    
+    echo "\n✅ Database fix completed successfully!\n";
+    echo "\nYou can now use the application without the database error.\n";
+    
+} catch (PDOException $e) {
+    echo "❌ Database error: " . $e->getMessage() . "\n";
+    echo "\nPlease make sure:\n";
+    echo "1. The database connection details in db.php are correct\n";
+    echo "2. The 'users' table exists in your database\n";
+    echo "3. You have the necessary database permissions\n";
+} catch (Exception $e) {
+    echo "❌ Error: " . $e->getMessage() . "\n";
+}

--- a/project-monitoring-system/fix_project_limits_table.sql
+++ b/project-monitoring-system/fix_project_limits_table.sql
@@ -1,0 +1,23 @@
+-- Fix for missing project_limits table
+-- This script creates the project_limits table that is required by the roles.php functions
+
+CREATE TABLE IF NOT EXISTS `project_limits` (
+    `id` INT(11) NOT NULL AUTO_INCREMENT,
+    `user_id` INT(11) NOT NULL,
+    `max_projects` INT(11) NOT NULL DEFAULT 10,
+    `set_by_admin_id` INT(11) DEFAULT NULL,
+    `limit_message` TEXT DEFAULT NULL,
+    `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `unique_user_limit` (`user_id`),
+    KEY `fk_set_by_admin` (`set_by_admin_id`),
+    CONSTRAINT `fk_project_limits_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE,
+    CONSTRAINT `fk_project_limits_admin` FOREIGN KEY (`set_by_admin_id`) REFERENCES `users` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Optional: Add default project limits for existing users
+-- This ensures all existing users get the default limit of 10 projects
+INSERT IGNORE INTO `project_limits` (`user_id`, `max_projects`)
+SELECT `id`, 10 FROM `users`
+WHERE `id` NOT IN (SELECT `user_id` FROM `project_limits`);


### PR DESCRIPTION
Add `project_limits` table definition and provide fix scripts to resolve 'Base table or view not found' errors.

The `project_limits` table was missing from the initial database schema, causing `SQLSTATE[42S02]: Base table or view not found: 1146` errors when the application attempted to access it (e.g., in `getUserUrlLimit()` within `includes/roles.php`). This PR ensures the table is included in the complete schema for new installations and provides immediate fix scripts for existing ones.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f2fa0ff-dd00-422f-81aa-b393fa79760a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f2fa0ff-dd00-422f-81aa-b393fa79760a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>